### PR TITLE
Update JBig2Image.cs

### DIFF
--- a/JBig2Decoder/Images/JBig2Image.cs
+++ b/JBig2Decoder/Images/JBig2Image.cs
@@ -284,7 +284,10 @@ namespace JBig2Decoder
 
                         if (ltp)
                         {
-                            duplicateRow(row, row - 1);
+                            // if the top row needs a predictor, we need to wrap around to the bottom row
+                            int target = row - 1;
+                            if (target < 0) target = (int)(height - 1);
+                            duplicateRow(row, target);
                             continue;
                         }
                     }


### PR DESCRIPTION
I encountered an image file where the top row had the predictor flag set. This caused an `IndexOutOfRangeException` in `FastBitSet` because it was trying to read row `-1`. I discovered that this indicates that the bottom row should be used as the predictor. Making this change allowed me to decode the image successfully.